### PR TITLE
Support for deploying clang-tidy as a library

### DIFF
--- a/before-deploy.sh
+++ b/before-deploy.sh
@@ -10,4 +10,5 @@ ln -s /usr/bin/FileCheck-8 $name/bin/FileCheck
 cp clang/tools/extra/clang-tidy/*.h $name/include
 cp clang/LICENSE.TXT $name/clang-LICENSE.TXT
 ln -s /usr/include/clang $name/lib/clang
+cp clang/build/lib/libclangTidyMain.a $name/lib
 tar -cJvf $name.tar.xz $name

--- a/plugin-support.patch
+++ b/plugin-support.patch
@@ -40,6 +40,51 @@ index 1a7535447cb..aad058ff30f 100644
    /// \brief Output warnings from headers matching this filter. Warnings from
    /// main files will always be displayed.
    llvm::Optional<std::string> HeaderFilterRegex;
+diff --git a/tools/extra/clang-tidy/tool/CMakeLists.txt b/tools/extra/clang-tidy/tool/CMakeLists.txt
+index f58cfea5518..4305e8f475f 100644
+--- a/tools/extra/clang-tidy/tool/CMakeLists.txt
++++ b/tools/extra/clang-tidy/tool/CMakeLists.txt
+@@ -5,13 +5,13 @@ set(LLVM_LINK_COMPONENTS
+   support
+   )
+ 
+-add_clang_tool(clang-tidy
++add_clang_library(clangTidyMain
+   ClangTidyMain.cpp
+   )
+-add_dependencies(clang-tidy
++add_dependencies(clangTidyMain
+   clang-headers
+   )
+-target_link_libraries(clang-tidy
++target_link_libraries(clangTidyMain
+   PRIVATE
+   clangAST
+   clangASTMatchers
+@@ -39,11 +39,22 @@ target_link_libraries(clang-tidy
+   )
+ 
+ if(CLANG_ENABLE_STATIC_ANALYZER)
+-  target_link_libraries(clang-tidy PRIVATE
++  target_link_libraries(clangTidyMain PRIVATE
+     clangTidyMPIModule
+   )
+ endif()
+ 
++# supress warning about unknown source file
++set(LLVM_OPTIONAL_SOURCES "ClangTidyMain.cpp")
++# using dummy source file to supress warning about no sources
++add_clang_tool(clang-tidy
++  ${LLVM_MAIN_SRC_DIR}/cmake/dummy.cpp
++  )
++target_link_libraries(clang-tidy
++  PRIVATE
++  clangTidyMain
++  )
++
+ install(PROGRAMS clang-tidy-diff.py
+   DESTINATION share/clang
+   COMPONENT clang-tidy)
 diff --git a/tools/extra/clang-tidy/tool/ClangTidyMain.cpp b/tools/extra/clang-tidy/tool/ClangTidyMain.cpp
 index 12a60244f34..50e4bad96d2 100644
 --- a/tools/extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -85,3 +130,40 @@ index 12a60244f34..50e4bad96d2 100644
    std::vector<std::string> EnabledChecks =
        getCheckNames(EffectiveOptions, AllowEnablingAnalyzerAlphaCheckers);
  
+diff --git a/tools/extra/test/clang-tidy/check_clang_tidy.py b/tools/extra/test/clang-tidy/check_clang_tidy.py
+index 9768011a3ef..7e1d1e370cf 100755
+--- a/tools/extra/test/clang-tidy/check_clang_tidy.py
++++ b/tools/extra/test/clang-tidy/check_clang_tidy.py
+@@ -20,6 +20,7 @@ Usage:
+     [-assume-filename=<file-with-source-extension>] \
+     [-check-suffix=<comma-separated-file-check-suffixes>] \
+     [-check-suffixes=<comma-separated-file-check-suffixes>] \
++    [-clang-tidy=<path/to/clang-tidy>] \
+     <source-file> <check-name> <temp-file> \
+     -- [optional clang-tidy arguments]
+ 
+@@ -53,6 +54,7 @@ def main():
+   parser.add_argument('-check-suffix', '-check-suffixes',
+                       default=[''], type=csv,
+                       help="comma-separated list of FileCheck suffixes")
++  parser.add_argument('-clang-tidy', default='clang-tidy')
+ 
+   args, extra_args = parser.parse_known_args()
+ 
+@@ -62,6 +64,7 @@ def main():
+   check_name = args.check_name
+   temp_file_name = args.temp_file_name
+   expect_clang_tidy_error = args.expect_clang_tidy_error
++  clang_tidy = args.clang_tidy
+ 
+   file_name_with_extension = assume_file_name or input_file_name
+   _, extension = os.path.splitext(file_name_with_extension)
+@@ -138,7 +141,7 @@ def main():
+   original_file_name = temp_file_name + ".orig"
+   write_file(original_file_name, cleaned_test)
+ 
+-  args = ['clang-tidy', temp_file_name, '-fix', '--checks=-*,' + check_name] + \
++  args = [clang_tidy, temp_file_name, '-fix', '--checks=-*,' + check_name] + \
+         clang_tidy_extra_args
+   if expect_clang_tidy_error:
+     args.insert(0, 'not')

--- a/plugin-support.patch
+++ b/plugin-support.patch
@@ -138,6 +138,46 @@ index 00000000000..c027d248738
 +++ b/tools/extra/clang-tidy/tool/dummy.cpp
 @@ -0,0 +1 @@
 +typedef int dummy;
+diff --git a/tools/extra/clang-tidy/tool/run-clang-tidy.py b/tools/extra/clang-tidy/tool/run-clang-tidy.py
+index 93635cbef16..a33d29a4130 100755
+--- a/tools/extra/clang-tidy/tool/run-clang-tidy.py
++++ b/tools/extra/clang-tidy/tool/run-clang-tidy.py
+@@ -76,7 +76,7 @@ def make_absolute(f, directory):
+ 
+ def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
+                         header_filter, extra_arg, extra_arg_before, quiet,
+-                        config):
++                        config, fix_errors):
+   """Gets a command line for clang-tidy."""
+   start = [clang_tidy_binary]
+   if header_filter is not None:
+@@ -102,6 +102,8 @@ def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
+       start.append('-quiet')
+   if config:
+       start.append('-config=' + config)
++  if fix_errors:
++      start.append('-fix-errors')
+   start.append(f)
+   return start
+ 
+@@ -160,7 +162,7 @@ def run_tidy(args, tmpdir, build_path, queue, lock, failed_files):
+     invocation = get_tidy_invocation(name, args.clang_tidy_binary, args.checks,
+                                      tmpdir, build_path, args.header_filter,
+                                      args.extra_arg, args.extra_arg_before,
+-                                     args.quiet, args.config)
++                                     args.quiet, args.config, args.fix_errors)
+ 
+     proc = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+     output, err = proc.communicate()
+@@ -207,6 +209,8 @@ def main():
+                       help='number of tidy instances to be run in parallel.')
+   parser.add_argument('files', nargs='*', default=['.*'],
+                       help='files to be processed (regex on path)')
++  parser.add_argument('-fix-errors', action='store_true', help='apply fix-its, '
++                      'even if compiler error is encountered')
+   parser.add_argument('-fix', action='store_true', help='apply fix-its')
+   parser.add_argument('-format', action='store_true', help='Reformat code '
+                       'after applying fixes')
 diff --git a/tools/extra/test/clang-tidy/check_clang_tidy.py b/tools/extra/test/clang-tidy/check_clang_tidy.py
 index 9768011a3ef..7e1d1e370cf 100755
 --- a/tools/extra/test/clang-tidy/check_clang_tidy.py

--- a/plugin-support.patch
+++ b/plugin-support.patch
@@ -41,14 +41,15 @@ index 1a7535447cb..aad058ff30f 100644
    /// main files will always be displayed.
    llvm::Optional<std::string> HeaderFilterRegex;
 diff --git a/tools/extra/clang-tidy/tool/CMakeLists.txt b/tools/extra/clang-tidy/tool/CMakeLists.txt
-index f58cfea5518..4305e8f475f 100644
+index f58cfea5518..1f9ebc0c3b1 100644
 --- a/tools/extra/clang-tidy/tool/CMakeLists.txt
 +++ b/tools/extra/clang-tidy/tool/CMakeLists.txt
-@@ -5,13 +5,13 @@ set(LLVM_LINK_COMPONENTS
+@@ -5,13 +5,14 @@ set(LLVM_LINK_COMPONENTS
    support
    )
  
 -add_clang_tool(clang-tidy
++set(LLVM_OPTIONAL_SOURCES "dummy.cpp")
 +add_clang_library(clangTidyMain
    ClangTidyMain.cpp
    )
@@ -61,7 +62,7 @@ index f58cfea5518..4305e8f475f 100644
    PRIVATE
    clangAST
    clangASTMatchers
-@@ -39,11 +39,22 @@ target_link_libraries(clang-tidy
+@@ -39,11 +40,22 @@ target_link_libraries(clang-tidy
    )
  
  if(CLANG_ENABLE_STATIC_ANALYZER)
@@ -75,7 +76,7 @@ index f58cfea5518..4305e8f475f 100644
 +set(LLVM_OPTIONAL_SOURCES "ClangTidyMain.cpp")
 +# using dummy source file to supress warning about no sources
 +add_clang_tool(clang-tidy
-+  ${LLVM_MAIN_SRC_DIR}/cmake/dummy.cpp
++  dummy.cpp
 +  )
 +target_link_libraries(clang-tidy
 +  PRIVATE
@@ -130,6 +131,13 @@ index 12a60244f34..50e4bad96d2 100644
    std::vector<std::string> EnabledChecks =
        getCheckNames(EffectiveOptions, AllowEnablingAnalyzerAlphaCheckers);
  
+diff --git a/tools/extra/clang-tidy/tool/dummy.cpp b/tools/extra/clang-tidy/tool/dummy.cpp
+new file mode 100644
+index 00000000000..c027d248738
+--- /dev/null
++++ b/tools/extra/clang-tidy/tool/dummy.cpp
+@@ -0,0 +1 @@
++typedef int dummy;
 diff --git a/tools/extra/test/clang-tidy/check_clang_tidy.py b/tools/extra/test/clang-tidy/check_clang_tidy.py
 index 9768011a3ef..7e1d1e370cf 100755
 --- a/tools/extra/test/clang-tidy/check_clang_tidy.py

--- a/targets
+++ b/targets
@@ -25,4 +25,6 @@ clangTidyFuchsiaModule
 clangTidyGoogleModule
 clangTidyMPIModule
 clangTidyObjCModule
+clangTidy
+clangTidyMain
 clang-tidy


### PR DESCRIPTION
Let's see if this works. I changed the `CMakeLists.txt` of `clang-tidy` to generate `libclangTidyMain` in addition to `clang-tidy`, main function included. `check_clang_tidy.py` was updated to accept a `clang-tidy` parameter so callers can specify the path to their custom `clang-tidy` executable.